### PR TITLE
Added --no-verify-ssl to command line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The CIF  Software Development Kit (SDK) for Python contains library code and exa
   
   cli = Client(token=1234,
                remote='https://localhost2:8443',
-               noverifyssl=1)
+               no_verify_ssl=1)
   
   ret = cli.search(query='example.com')
   make_table(ret)


### PR DESCRIPTION
Adding --no-verify-ssl option to command line example since default install does not provide a signed cert or an option to install one. This should help ease beginner pain.
